### PR TITLE
docs: add type imports and comment to example

### DIFF
--- a/src/routes/docs/+page.svx
+++ b/src/routes/docs/+page.svx
@@ -110,6 +110,8 @@ To use the `edra` component, you can import it in your Svelte component and use 
 ```svelte{h[2,4-7,9-11,16,18]%f[my-editor.svelte]}
 <script lang="ts">
 	import { Edra, EdraToolbar } from '$lib/components/edra/shadcn/index.js';
+	import type { Content, Editor } from '@tiptap/core';
+	import { Transaction } from '@tiptap/pm/state';
 
 	let editor = $state<Editor>();
 	let content = $state<Content>();
@@ -117,7 +119,7 @@ To use the `edra` component, you can import it in your Svelte component and use 
 	let showMenu = $state(true);
 
 	function onUpdate(props: { editor: Editor; transaction: Transaction }) {
-		saveContent(props.editor.getJSON());
+		saveContent(props.editor.getJSON()); // save the content in your preferred way
 	}
 </script>
 

--- a/src/routes/docs/+page.svx
+++ b/src/routes/docs/+page.svx
@@ -109,7 +109,7 @@ To use the `edra` component, you can import it in your Svelte component and use 
 
 ```svelte{h[2,4-7,9-11,16,18]%f[my-editor.svelte]}
 <script lang="ts">
-	import { Edra, EdraToolbar } from '$lib/components/edra/shadcn/index.js';
+	import { Edra, EdraToolbar } from '$lib/components/edra/shadcn';
 	import type { Content, Editor } from '@tiptap/core';
 	import { Transaction } from '@tiptap/pm/state';
 


### PR DESCRIPTION
- added type imports to the example so that it is a bit more complete/copypastable
- a comment to indicate that the `saveContent` function is a self defined function 