### PR TITLE
Feats: Improved Edra, EdraToolbar, EdraBubbleMenu and more

### DIFF
--- a/src/lib/components/custom/demo-editor-settings.svelte
+++ b/src/lib/components/custom/demo-editor-settings.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import { buttonVariants } from '../ui/button/button.svelte';
+	import { Checkbox } from '../ui/checkbox/index.js';
+	import * as Dialog from '../ui/dialog/index.js';
+	import Settings from 'lucide-svelte/icons/settings';
+	import { Label } from '../ui/label/index.js';
+
+	interface Props {
+		showToolBar: boolean;
+		showBubbleMenus: boolean;
+		editable: boolean;
+	}
+
+	let {
+		showToolBar = $bindable(true),
+		showBubbleMenus = $bindable(true),
+		editable = $bindable(true)
+	}: Props = $props();
+</script>
+
+<Dialog.Root>
+	<Dialog.Trigger class={buttonVariants({ variant: 'outline' })}>
+		<Settings />
+		<span>Demo Settings</span>
+	</Dialog.Trigger>
+	<Dialog.Content class="h-fit max-h-[95vh] w-80 max-w-[95vw] p-4">
+		<Dialog.Header class="mb-4">
+			<Dialog.Title>Demo Edra Settings</Dialog.Title>
+		</Dialog.Header>
+		<div class="flex flex-col items-start gap-6">
+			<div class="flex w-full items-center gap-2">
+				<Checkbox id="toolbar" bind:checked={showToolBar} />
+				<Label for="toolbar" class="w-full cursor-pointer text-sm font-medium leading-none"
+					>Show Editor Toolbar</Label
+				>
+			</div>
+			<div class="flex w-full items-center gap-2">
+				<Checkbox id="menus" bind:checked={showBubbleMenus} />
+				<Label for="menus" class="w-full cursor-pointer text-sm font-medium leading-none"
+					>Show Editor Menus</Label
+				>
+			</div>
+			<div class="flex w-full items-center gap-2">
+				<Checkbox id="editable" bind:checked={editable} />
+				<Label for="editable" class="w-full cursor-pointer text-sm font-medium leading-none"
+					>Editable</Label
+				>
+			</div>
+		</div>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/custom/editor-output.svelte
+++ b/src/lib/components/custom/editor-output.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import * as Dialog from '$lib/components/ui/dialog/index.js';
+	import FileJson from 'lucide-svelte/icons/file-json';
+	import { Button, buttonVariants } from '../ui/button/index.js';
+	import ShikiCode from './shiki-code.svelte';
+	import { toast } from 'svelte-sonner';
+	import Expand from 'lucide-svelte/icons/maximize-2';
+	import Restore from 'lucide-svelte/icons/minimize-2';
+	import { cn } from '$lib/utils.js';
+
+	interface Props {
+		code: string;
+	}
+
+	let { code }: Props = $props();
+
+	let expand = $state(false);
+
+	function handleExpand() {
+		expand = !expand;
+	}
+</script>
+
+<Dialog.Root>
+	<Dialog.Trigger class={buttonVariants({ variant: 'outline' })}>
+		<FileJson /> Show Output
+	</Dialog.Trigger>
+	<Dialog.Content
+		class={cn(
+			'h-[95%] w-[95vw] transition-all duration-500 sm:h-[80%] sm:min-w-[50%]',
+			expand && 'sm:h-[95%] sm:min-w-[95vw]'
+		)}
+	>
+		<Button
+			variant="ghost"
+			class="absolute right-12 top-4 hidden size-4 rounded-sm bg-muted p-0 text-muted-foreground opacity-70 hover:opacity-100 sm:inline-flex"
+			title={expand ? 'Restore' : 'Expand'}
+			onclick={handleExpand}
+		>
+			{#if expand}
+				<Restore class="!size-3" />
+			{:else}
+				<Expand class="!size-3" />
+			{/if}
+		</Button>
+		<Dialog.Header>
+			<Dialog.Title>JSON Output</Dialog.Title>
+			<Dialog.Description>Observe the JSON output of the editor content</Dialog.Description>
+		</Dialog.Header>
+		<ShikiCode class="size-full overflow-auto" {code} lang="json" />
+		<Button
+			variant="outline"
+			class="ml-auto w-fit"
+			onclick={() => {
+				navigator.clipboard.writeText(code);
+				toast.success(`Copied to clipboard`);
+			}}>Copy JSON Output</Button
+		>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/edra/headless/editor.svelte
+++ b/src/lib/edra/headless/editor.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { type Editor } from '@tiptap/core';
-	import { onDestroy, onMount } from 'svelte';
+	import { onMount } from 'svelte';
 
 	import { initiateEditor } from '../editor.js';
 	import './style.css';
@@ -45,10 +45,12 @@
 		class: className = '',
 		content = undefined,
 		editable = true,
-		showMenu = true,
+		showBubbleMenus = true,
 		limit = undefined,
 		editor = $bindable<Editor | undefined>(),
-		onUpdate
+		showSlashCommand = true,
+		onUpdate,
+		children
 	}: EdraProps = $props();
 
 	let element = $state<HTMLElement>();
@@ -74,7 +76,7 @@
 				AudioExtended(AudioExtendedComponent),
 				ImageExtended(ImageExtendedComponent),
 				VideoExtended(VideoExtendedComponent),
-				slashcommand(SlashCommandList)
+				...(showSlashCommand ? [slashcommand(SlashCommandList)] : [])
 			],
 			{
 				editable,
@@ -85,11 +87,7 @@
 				}
 			}
 		);
-	});
-
-	onDestroy(() => {
-		console.log('Destroying editor');
-		editor?.destroy();
+		return () => editor?.destroy();
 	});
 </script>
 
@@ -98,11 +96,11 @@
 {/if}
 
 <div class={`edra ${className}`}>
-	{#if editor && showMenu}
+	{@render children?.()}
+	{#if editor && showBubbleMenus}
 		<LinkMenu {editor} />
 		<TableRowMenu {editor} />
 		<TableColMenu {editor} />
-		<BubbleMenu {editor} />
 	{/if}
 	{#if !editor}
 		<div class="edra-loading">

--- a/src/lib/edra/headless/index.ts
+++ b/src/lib/edra/headless/index.ts
@@ -1,2 +1,3 @@
 export { default as Edra } from './editor.svelte';
 export { default as EdraToolbar } from './toolbar.svelte';
+export { default as EdraBubbleMenu } from './menus/bubble-menu.svelte';

--- a/src/lib/edra/headless/menus/bubble-menu.svelte
+++ b/src/lib/edra/headless/menus/bubble-menu.svelte
@@ -4,11 +4,14 @@
 	import { commands } from '../../commands/commands.js';
 	import EdraToolBarIcon from '../components/EdraToolBarIcon.svelte';
 	import type { ShouldShowProps } from '../../utils.js';
+	import type { Snippet } from 'svelte';
 
 	interface Props {
+		class?: string;
 		editor: Editor;
+		children?: Snippet<[]>;
 	}
-	const { editor }: Props = $props();
+	const { class: className = '', editor, children }: Props = $props();
 
 	const bubbleMenuCommands = [
 		...commands['text-formatting'].commands,
@@ -69,7 +72,7 @@
 
 <BubbleMenu
 	{editor}
-	class="bubble-menu-wrapper"
+	class={`bubble-menu-wrapper ${className}`}
 	{shouldShow}
 	pluginKey="bubble-menu"
 	updateDelay={100}
@@ -95,45 +98,49 @@
 		maxWidth: 'calc(100vw - 16px)'
 	}}
 >
-	{#each bubbleMenuCommands as command}
-		<EdraToolBarIcon {command} {editor} />
-	{/each}
+	{#if children}
+		{@render children()}
+	{:else}
+		{#each bubbleMenuCommands as command}
+			<EdraToolBarIcon {command} {editor} />
+		{/each}
 
-	<EdraToolBarIcon command={fontCommands[0]} {editor} />
-	<span>{editor.getAttributes('textStyle').fontSize ?? '16px'}</span>
-	<EdraToolBarIcon command={fontCommands[1]} {editor} />
+		<EdraToolBarIcon command={fontCommands[0]} {editor} />
+		<span>{editor.getAttributes('textStyle').fontSize ?? '16px'}</span>
+		<EdraToolBarIcon command={fontCommands[1]} {editor} />
 
-	<EdraToolBarIcon
-		command={colorCommands[0]}
-		{editor}
-		style={`color: ${editor.getAttributes('textStyle').color};`}
-		onclick={() => {
-			const color = editor.getAttributes('textStyle').color;
-			const hasColor = editor.isActive('textStyle', { color });
-			if (hasColor) {
-				editor.chain().focus().unsetColor().run();
-			} else {
-				const color = prompt('Enter the color of the text:');
-				if (color !== null) {
-					editor.chain().focus().setColor(color).run();
+		<EdraToolBarIcon
+			command={colorCommands[0]}
+			{editor}
+			style={`color: ${editor.getAttributes('textStyle').color};`}
+			onclick={() => {
+				const color = editor.getAttributes('textStyle').color;
+				const hasColor = editor.isActive('textStyle', { color });
+				if (hasColor) {
+					editor.chain().focus().unsetColor().run();
+				} else {
+					const color = prompt('Enter the color of the text:');
+					if (color !== null) {
+						editor.chain().focus().setColor(color).run();
+					}
 				}
-			}
-		}}
-	/>
-	<EdraToolBarIcon
-		command={colorCommands[1]}
-		{editor}
-		style={`background-color: ${editor.getAttributes('highlight').color};`}
-		onclick={() => {
-			const hasHightlight = editor.isActive('highlight');
-			if (hasHightlight) {
-				editor.chain().focus().unsetHighlight().run();
-			} else {
-				const color = prompt('Enter the color of the highlight:');
-				if (color !== null) {
-					editor.chain().focus().setHighlight({ color }).run();
+			}}
+		/>
+		<EdraToolBarIcon
+			command={colorCommands[1]}
+			{editor}
+			style={`background-color: ${editor.getAttributes('highlight').color};`}
+			onclick={() => {
+				const hasHightlight = editor.isActive('highlight');
+				if (hasHightlight) {
+					editor.chain().focus().unsetHighlight().run();
+				} else {
+					const color = prompt('Enter the color of the highlight:');
+					if (color !== null) {
+						editor.chain().focus().setHighlight({ color }).run();
+					}
 				}
-			}
-		}}
-	/>
+			}}
+		/>
+	{/if}
 </BubbleMenu>

--- a/src/lib/edra/headless/toolbar.svelte
+++ b/src/lib/edra/headless/toolbar.svelte
@@ -3,69 +3,76 @@
 	import { commands } from '../commands/commands.js';
 	import EdraToolBarIcon from './components/EdraToolBarIcon.svelte';
 	import SearcnAndReplace from './components/SearcnAndReplace.svelte';
+	import type { Snippet } from 'svelte';
 
 	interface Props {
 		class?: string;
 		editor: Editor;
+		children?: Snippet<[]>;
 	}
 
-	const { class: className = '', editor }: Props = $props();
+	const { class: className = '', editor, children }: Props = $props();
 
 	let showSearchAndReplace = $state(false);
 
 	const colorCommands = commands.colors.commands;
 	const fontCommands = commands.fonts.commands;
+	const excludedCommands = ['colors', 'fonts'];
 </script>
 
 <div class={`edra-toolbar ${className}`}>
-	{#if !showSearchAndReplace}
-		{#each Object.keys(commands).filter((key) => key !== 'colors' && key !== 'fonts') as keys}
-			{@const groups = commands[keys].commands}
-			{#each groups as command}
-				<EdraToolBarIcon {command} {editor} />
+	{#if children}
+		{@render children()}
+	{:else}
+		{#if !showSearchAndReplace}
+			{#each Object.keys(commands).filter((key) => !excludedCommands.includes(key)) as keys}
+				{@const groups = commands[keys].commands}
+				{#each groups as command}
+					<EdraToolBarIcon {command} {editor} />
+				{/each}
+				<span class="separator"></span>
 			{/each}
+
+			<EdraToolBarIcon command={fontCommands[0]} {editor} />
+			<span>{editor.getAttributes('textStyle').fontSize ?? '16px'}</span>
+			<EdraToolBarIcon command={fontCommands[1]} {editor} />
+
 			<span class="separator"></span>
-		{/each}
 
-		<EdraToolBarIcon command={fontCommands[0]} {editor} />
-		<span>{editor.getAttributes('textStyle').fontSize ?? '16px'}</span>
-		<EdraToolBarIcon command={fontCommands[1]} {editor} />
-
-		<span class="separator"></span>
-
-		<EdraToolBarIcon
-			command={colorCommands[0]}
-			{editor}
-			style={`color: ${editor.getAttributes('textStyle').color};`}
-			onclick={() => {
-				const color = editor.getAttributes('textStyle').color;
-				const hasColor = editor.isActive('textStyle', { color });
-				if (hasColor) {
-					editor.chain().focus().unsetColor().run();
-				} else {
-					const color = prompt('Enter the color of the text:');
-					if (color !== null) {
-						editor.chain().focus().setColor(color).run();
+			<EdraToolBarIcon
+				command={colorCommands[0]}
+				{editor}
+				style={`color: ${editor.getAttributes('textStyle').color};`}
+				onclick={() => {
+					const color = editor.getAttributes('textStyle').color;
+					const hasColor = editor.isActive('textStyle', { color });
+					if (hasColor) {
+						editor.chain().focus().unsetColor().run();
+					} else {
+						const color = prompt('Enter the color of the text:');
+						if (color !== null) {
+							editor.chain().focus().setColor(color).run();
+						}
 					}
-				}
-			}}
-		/>
-		<EdraToolBarIcon
-			command={colorCommands[1]}
-			{editor}
-			style={`background-color: ${editor.getAttributes('highlight').color};`}
-			onclick={() => {
-				const hasHightlight = editor.isActive('highlight');
-				if (hasHightlight) {
-					editor.chain().focus().unsetHighlight().run();
-				} else {
-					const color = prompt('Enter the color of the highlight:');
-					if (color !== null) {
-						editor.chain().focus().setHighlight({ color }).run();
+				}}
+			/>
+			<EdraToolBarIcon
+				command={colorCommands[1]}
+				{editor}
+				style={`background-color: ${editor.getAttributes('highlight').color};`}
+				onclick={() => {
+					const hasHightlight = editor.isActive('highlight');
+					if (hasHightlight) {
+						editor.chain().focus().unsetHighlight().run();
+					} else {
+						const color = prompt('Enter the color of the highlight:');
+						if (color !== null) {
+							editor.chain().focus().setHighlight({ color }).run();
+						}
 					}
-				}
-			}}
-		/>
+				}}
+			/>
+		{/if}
+		<SearcnAndReplace {editor} bind:show={showSearchAndReplace} />
 	{/if}
-	<SearcnAndReplace {editor} bind:show={showSearchAndReplace} />
 </div>

--- a/src/lib/edra/shadcn/editor.svelte
+++ b/src/lib/edra/shadcn/editor.svelte
@@ -29,7 +29,6 @@
 	import TableRowMenu from './menus/table-row-menu.svelte';
 	import slashcommand from '../extensions/slash-command/slashcommand.js';
 	import SlashCommandList from './components/SlashCommandList.svelte';
-	import BubbleMenu from './menus/bubble-menu.svelte';
 	import LoaderCircle from 'lucide-svelte/icons/loader-circle';
 	import type { EdraProps } from '../utils.js';
 	import DragHandle from '../drag-handle.svelte';
@@ -44,11 +43,13 @@
 	let {
 		class: className = '',
 		content = undefined,
-		showMenu = true,
+		showBubbleMenus = true,
 		limit = undefined,
 		editable = true,
 		editor = $bindable<Editor | undefined>(),
-		onUpdate
+		showSlashCommand = true,
+		onUpdate,
+		children
 	}: EdraProps = $props();
 
 	let element = $state<HTMLElement>();
@@ -74,7 +75,7 @@
 				ImageExtended(ImageExtendedComponent),
 				VideoExtended(VideoExtendedComponent),
 				AudioExtended(AudioExtendedComponent),
-				slashcommand(SlashCommandList)
+				...(showSlashCommand ? [slashcommand(SlashCommandList)] : [])
 			],
 			{
 				editable,
@@ -85,6 +86,7 @@
 				}
 			}
 		);
+		return () => editor?.destroy();
 	});
 </script>
 
@@ -93,11 +95,11 @@
 {/if}
 
 <div class={cn('edra', className)}>
-	{#if editor && showMenu}
+	{@render children?.()}
+	{#if editor && showBubbleMenus}
 		<LinkMenu {editor} />
 		<TableColMenu {editor} />
 		<TableRowMenu {editor} />
-		<BubbleMenu {editor} />
 	{/if}
 	{#if !editor}
 		<div class="flex size-full items-center justify-center gap-4 text-xl">

--- a/src/lib/edra/shadcn/index.ts
+++ b/src/lib/edra/shadcn/index.ts
@@ -1,2 +1,3 @@
 export { default as Edra } from './editor.svelte';
 export { default as EdraToolbar } from './toolbar.svelte';
+export { default as EdraBubbleMenu } from './menus/bubble-menu.svelte';

--- a/src/lib/edra/shadcn/menus/bubble-menu.svelte
+++ b/src/lib/edra/shadcn/menus/bubble-menu.svelte
@@ -6,12 +6,16 @@
 	import EdraToolBarIcon from '../components/EdraToolBarIcon.svelte';
 	import FontSize from '../components/FontSize.svelte';
 	import QuickColor from '../components/QuickColor.svelte';
+	import type { Snippet } from 'svelte';
+	import { cn } from '$lib/utils.js';
 
 	interface Props {
+		class?: string;
 		editor: Editor;
+		children?: Snippet<[]>;
 	}
 
-	let { editor }: Props = $props();
+	let { class: className = '', editor, children }: Props = $props();
 
 	const excludeCommands = ['undo-redo', 'media', 'table', 'colors', 'fonts', 'lists'];
 
@@ -65,7 +69,10 @@
 
 <BubbleMenu
 	{editor}
-	class="flex h-fit w-fit items-center gap-1 rounded-md border bg-background/90 p-0.5 backdrop-blur-md"
+	class={cn(
+		'edra-bubblemenu flex h-fit w-fit items-center gap-1 rounded-md border bg-background/90 p-0.5 backdrop-blur-md',
+		className
+	)}
 	{shouldShow}
 	pluginKey="bubble-menu"
 	updateDelay={100}
@@ -91,12 +98,16 @@
 		maxWidth: 'calc(100vw - 16px)'
 	}}
 >
-	{#each Object.keys(commands).filter((key) => !excludeCommands.includes(key)) as keys}
-		{@const groups = commands[keys].commands}
-		{#each groups as command}
-			<EdraToolBarIcon {command} {editor} />
+	{#if children}
+		{@render children()}
+	{:else}
+		{#each Object.keys(commands).filter((key) => !excludeCommands.includes(key)) as keys}
+			{@const groups = commands[keys].commands}
+			{#each groups as command}
+				<EdraToolBarIcon {command} {editor} />
+			{/each}
 		{/each}
-	{/each}
-	<FontSize {editor} />
-	<QuickColor {editor} />
+		<FontSize {editor} />
+		<QuickColor {editor} />
+	{/if}
 </BubbleMenu>

--- a/src/lib/edra/shadcn/toolbar.svelte
+++ b/src/lib/edra/shadcn/toolbar.svelte
@@ -6,13 +6,17 @@
 	import FontSize from './components/FontSize.svelte';
 	import SearchAndReplace from './components/SearchAndReplace.svelte';
 	import { cn } from '$lib/utils.js';
+	import type { Snippet } from 'svelte';
 
 	interface Props {
 		class?: string;
 		editor: Editor;
+		children?: Snippet<[]>;
 	}
 
-	const { class: className = '', editor }: Props = $props();
+	const { class: className = '', editor, children }: Props = $props();
+
+	const excludedCommands = ['colors', 'fonts'];
 </script>
 
 <div
@@ -21,13 +25,17 @@
 		className
 	)}
 >
-	{#each Object.keys(commands).filter((key) => key !== 'colors' && key !== 'fonts') as keys}
-		{@const groups = commands[keys].commands}
-		{#each groups as command}
-			<EdraToolBarIcon {command} {editor} />
+	{#if children}
+		{@render children()}
+	{:else}
+		{#each Object.keys(commands).filter((key) => !excludedCommands.includes(key)) as keys}
+			{@const groups = commands[keys].commands}
+			{#each groups as command}
+				<EdraToolBarIcon {command} {editor} />
+			{/each}
 		{/each}
-	{/each}
-	<FontSize {editor} />
-	<QuickColor {editor} />
-	<SearchAndReplace {editor} />
+		<FontSize {editor} />
+		<QuickColor {editor} />
+		<SearchAndReplace {editor} />
+	{/if}
 </div>

--- a/src/lib/edra/utils.ts
+++ b/src/lib/edra/utils.ts
@@ -4,6 +4,7 @@ import { Decoration, DecorationSet } from '@tiptap/pm/view';
 import type { EditorState, Transaction } from '@tiptap/pm/state';
 import type { EditorView } from '@tiptap/pm/view';
 import { browser } from '$app/environment';
+import type { Snippet } from 'svelte';
 
 export interface ShouldShowProps {
 	editor: Editor;
@@ -106,12 +107,14 @@ export interface EdraProps {
 	class?: string;
 	content?: Content;
 	editable?: boolean;
-	showMenu?: boolean;
+	showBubbleMenus?: boolean;
 	limit?: number;
 	editor?: Editor;
+	showSlashCommand?: boolean;
 	/**
 	 * Callback function to be called when the content is updated
 	 * @param content
 	 */
 	onUpdate?: (props: { editor: Editor; transaction: Transaction }) => void;
+	children?: Snippet<[]>;
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,20 +2,16 @@
 	import { browser } from '$app/environment';
 	import type { Content, Editor } from '@tiptap/core';
 	import type { Transaction } from '@tiptap/pm/state';
-	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
-	import { Label } from '$lib/components/ui/label/index.js';
 	import { cn } from '$lib/utils.js';
 	import GridPattern from '$lib/components/custom/grid-pattern.svelte';
-	import { Button, buttonVariants } from '$lib/components/ui/button/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
 	import Document from 'lucide-svelte/icons/file-text';
 	import GitHub from 'lucide-svelte/icons/github';
-	import * as Dialog from '$lib/components/ui/dialog/index.js';
-	import FileJson from 'lucide-svelte/icons/file-json';
-	import ShikiCode from '$lib/components/custom/shiki-code.svelte';
-	import { toast } from 'svelte-sonner';
-	import { Edra, EdraToolbar } from '$lib/edra/shadcn/index.js';
+	import { Edra, EdraToolbar, EdraBubbleMenu } from '$lib/edra/shadcn/index.js';
 	import { slide } from 'svelte/transition';
 	import defaultContent from '$lib/default_content.js';
+	import DemoEditorSettings from '$lib/components/custom/demo-editor-settings.svelte';
+	import EditorOutput from '$lib/components/custom/editor-output.svelte';
 
 	let content = $state<Content>();
 	let editor = $state<Editor>();
@@ -26,7 +22,13 @@
 	});
 
 	let showToolBar = $state(true);
-	let showMenu = $state(true);
+	let showBubbleMenus = $state(true);
+	let editable = $state(true);
+
+	$effect(() => {
+		console.log('editable', editable);
+		editor?.setEditable(editable);
+	});
 
 	if (browser) {
 		const rawDataString = localStorage.getItem('edra-content');
@@ -74,46 +76,23 @@
 			</Button>
 		</div>
 		<div class="size-full *:my-2">
+			<div class="text-center text-xl font-bold">Explore Demo</div>
 			<div class="flex flex-col items-center justify-center gap-4 sm:flex-row">
-				<div class="flex items-center gap-2">
-					<Checkbox id="toolbar" bind:checked={showToolBar} />
-					<Label for="toolbar" class="text-sm font-medium leading-none">Show Editor Toolbar</Label>
-				</div>
-				<div class="flex items-center gap-2">
-					<Checkbox id="menus" bind:checked={showMenu} />
-					<Label for="menus" class="text-sm font-medium leading-none">Show Editor Menus</Label>
-				</div>
-				<Dialog.Root>
-					<Dialog.Trigger class={buttonVariants({ variant: 'outline' })}>
-						<FileJson /> Show Output
-					</Dialog.Trigger>
-					<Dialog.Content class="h-[95%] w-[95vw] sm:h-[80%] sm:min-w-[50%]">
-						<Dialog.Header>
-							<Dialog.Title>JSON Output</Dialog.Title>
-							<Dialog.Description>Observe the JSON output of the editor content</Dialog.Description>
-						</Dialog.Header>
-						{@const stringContent = JSON.stringify(content, null, 2)}
-						<ShikiCode class="size-full overflow-auto" code={stringContent} lang="json" />
-						<Button
-							variant="outline"
-							class="ml-auto w-fit"
-							onclick={() => {
-								navigator.clipboard.writeText(stringContent);
-								toast.success(`Copied to clipboard`);
-							}}>Copy JSON Output</Button
-						>
-					</Dialog.Content>
-				</Dialog.Root>
+				<DemoEditorSettings bind:showToolBar bind:showBubbleMenus bind:editable />
+				<EditorOutput code={JSON.stringify(content, null, 2)} />
 			</div>
 		</div>
 	</div>
 	<div class="m-auto flex h-[35rem] w-[95%] flex-col rounded border sm:w-[85%]">
-		{#if editor && showToolBar}
-			<div transition:slide>
-				<EdraToolbar {editor} />
-			</div>
+		{#if editor}
+			{#if showToolBar}
+				<div transition:slide>
+					<EdraToolbar {editor} />
+				</div>
+			{/if}
+			<EdraBubbleMenu {editor} />
 		{/if}
-		<Edra class="overflow-auto" bind:editor {showMenu} {content} {onUpdate} />
+		<Edra class="overflow-auto" bind:editor {editable} {showBubbleMenus} {content} {onUpdate} />
 	</div>
 </div>
 


### PR DESCRIPTION
The following features are added

- Edra now takes optional `children` 
- EdraToolbar now takes optional `children` and if no `children` is provided, then renders the defaults
- Simimarly, EdraBubbleMenu now also takes optional `children` and if no `children` is provided, then renders the defaults. It's moved out of `Edra` component and now need to be set just like `EdraToolbar`
- Introducing new props in `Edra`, showSlashCommand as boolean which defaults to `true` and if set `false`, `SlashCommands` will not be rendered. 
- Improved the landing page, by introducing `demo editor` settings dialog and `JSON output` dialog with expand feat