### PR TITLE
fix: svelte-renderer trying to unmount already unmounted component

### DIFF
--- a/src/lib/edra/headless/components/SlashCommandList.svelte
+++ b/src/lib/edra/headless/components/SlashCommandList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onDestroy } from 'svelte';
 	import { icons } from 'lucide-svelte';
 
 	interface Props {
@@ -88,6 +89,8 @@
 		}
 		return false;
 	}
+
+	onDestroy(() => props.markDestroyed());
 </script>
 
 <svelte:window onkeydown={handleKeyDown} />

--- a/src/lib/edra/shadcn/components/SlashCommandList.svelte
+++ b/src/lib/edra/shadcn/components/SlashCommandList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onDestroy } from 'svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { cn } from '$lib/utils.js';
 	import { icons } from 'lucide-svelte';
@@ -90,6 +91,8 @@
 		}
 		return false;
 	}
+
+	onDestroy(() => props.markDestroyed());
 </script>
 
 <svelte:window onkeydown={handleKeyDown} />


### PR DESCRIPTION
If the component mounted by SvelteRendered was already unmounted (for example, if the parent was unmounted), Svelte will raise the following warning:
```
[svelte] lifecycle_double_unmount
Tried to unmount a component that was not mounted https://svelte.dev/e/lifecycle_double_unmount
```

Edra will still work normally but the warning was getting annoying.